### PR TITLE
Create APT28-Sofacy

### DIFF
--- a/threat/actor/APT28-Sofacy
+++ b/threat/actor/APT28-Sofacy
@@ -1,0 +1,27 @@
+threat actor: APT28 (Sofacy)  
+
+Background:
+
+APT28 is known for conducting sophisticated and long-term cyber espionage campaigns primarily targeting government entities, military organizations, and defense contractors. Their operations have spanned multiple countries, with a particular focus on Eastern European nations and NATO member states.
+Notable Incidents:
+
+NATO and Eastern European Targets: APT28 has targeted various Eastern European countries, especially those that were part of the former Soviet bloc. They have also targeted NATO member states. Their attacks often involve spear-phishing emails and malicious documents designed to steal sensitive information.
+
+U.S. Political Targets: APT28 gained significant attention for its alleged involvement in cyberattacks related to the 2016 U.S. Presidential election. U.S. intelligence agencies have accused APT28 of hacking into the Democratic National Committee (DNC) servers and releasing sensitive documents through platforms like WikiLeaks, with the goal of influencing the election.
+
+Olympic Games: APT28 has also been linked to cyberattacks targeting the Olympic Games. For instance, they were suspected of being involved in attacks on the 2018 Winter Olympics in Pyeongchang, South Korea. These attacks disrupted the Games' IT infrastructure and were seen as retaliatory measures against South Korea.
+
+Attribution:
+
+Attribution in the world of cyber espionage is challenging, but several factors have led cybersecurity experts and intelligence agencies to attribute APT28 to Russia and the GRU:
+Technical similarities in malware and infrastructure used by APT28 and other Russian-backed APT groups.
+The group's consistent focus on Russian strategic interests.
+Analysis of the group's tactics, techniques, and procedures (TTPs) by various cybersecurity firms and government agencies.
+Information from insider sources and defectors.
+Sources of Intelligence:
+
+Intelligence related to APT28 comes from a variety of sources, including:
+Cybersecurity companies: Many cybersecurity firms closely track APT28's activities and share threat intelligence.
+Government agencies: Intelligence agencies such as the U.S. Cybersecurity and Infrastructure Security Agency (CISA) and the UK's National Cyber Security Centre (NCSC) have analyzed APT28's actions.
+Open-source reporting: News outlets and research organizations often report on APT28's activities based on public information and expert analysis.
+Insider sources: In some cases, defectors or individuals with knowledge of Russian intelligence operations have provided valuable insights.


### PR DESCRIPTION
### threat template
Threat actor:
APT28, also known as Sofacy, is a notorious Advanced Persistent Threat (APT) group that has been active since at least 2007. APT28 is widely believed to have ties to the Russian government, particularly the Russian military intelligence agency GRU (Main Intelligence Directorate).
Background:
APT28 is known for conducting sophisticated and long-term cyber espionage campaigns primarily targeting government entities, military organizations, and defense contractors. Their operations have spanned multiple countries, with a particular focus on Eastern European nations and NATO member states.
notable incidents:
NATO and Eastern European Targets: APT28 has targeted various Eastern European countries, especially those that were part of the former Soviet bloc. They have also targeted NATO member states. Their attacks often involve spear-phishing emails and malicious documents designed to steal sensitive information.

U.S. Political Targets: APT28 gained significant attention for its alleged involvement in cyberattacks related to the 2016 U.S. Presidential election. U.S. intelligence agencies have accused APT28 of hacking into the Democratic National Committee (DNC) servers and releasing sensitive documents through platforms like WikiLeaks, with the goal of influencing the election.

Olympic Games: APT28 has also been linked to cyberattacks targeting the Olympic Games. For instance, they were suspected of being involved in attacks on the 2018 Winter Olympics in Pyeongchang, South Korea. These attacks disrupted the Games' IT infrastructure and were seen as retaliatory measures against South Korea.
Attribution:
Attribution in the world of cyber espionage is challenging, but several factors have led cybersecurity experts and intelligence agencies to attribute APT28 to Russia and the GRU:
Technical similarities in malware and infrastructure used by APT28 and other Russian-backed APT groups.
The group's consistent focus on Russian strategic interests.
Analysis of the group's tactics, techniques, and procedures (TTPs) by various cybersecurity firms and government agencies.
Information from insider sources and defectors.
sources of intelligence:
Intelligence related to APT28 comes from a variety of sources, including:
Cybersecurity companies: Many cybersecurity firms closely track APT28's activities and share threat intelligence.
Government agencies: Intelligence agencies such as the U.S. Cybersecurity and Infrastructure Security Agency (CISA) and the UK's National Cyber Security Centre (NCSC) have analyzed APT28's actions.
Open-source reporting: News outlets and research organizations often report on APT28's activities based on public information and expert analysis.
Insider sources: In some cases, defectors or individuals with knowledge of Russian intelligence operations have provided valuable insights.
